### PR TITLE
Adding app homepage in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "my-app",
+  "homepage": "https://apps.dura.science/arma3loadouts",
   "version": "0.1.0",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Adding app homepage so the sub-directory prefix is applied in asset-manifest.
This is so the app can be hosted in it's sub-directory on the apps.dura.science site.